### PR TITLE
fix when client_id not found when hydra return 401.

### DIFF
--- a/src/ensureHydraClient.js
+++ b/src/ensureHydraClient.js
@@ -34,7 +34,7 @@ async function ensureHydraClient(hydraAdminUrl) {
     headers: { "Content-Type": "application/json" }
   });
 
-  if (![200, 404].includes(getClientResponse.status)) {
+  if (![200, 404, 401].includes(getClientResponse.status)) {
     console.error(await getClientResponse.text());
     throw new Error(`Could not get Hydra client [${getClientResponse.status}]`);
   }

--- a/src/ensureHydraClient.js
+++ b/src/ensureHydraClient.js
@@ -26,9 +26,13 @@ const hydraClient = {
  *   is exposed on the internal network. Ensure that it is not exposed to the
  *   public Internet in production.
  * @param {String} hydraAdminUrl Hydra private admin URL
+ * @param {String} userId userId from command Input
  * @returns {Promise<undefined>} Nothing
  */
-async function ensureHydraClient(hydraAdminUrl) {
+async function ensureHydraClient(hydraAdminUrl, userId) {
+  let {client_id, ...rest} = hydraClient;
+  let hydraClientUpd = {'client_id':userId, ...rest};
+
   const getClientResponse = await fetch(makeAbsolute(`/clients/${OAUTH2_CLIENT_ID}`, hydraAdminUrl), {
     method: "GET",
     headers: { "Content-Type": "application/json" }
@@ -44,7 +48,7 @@ async function ensureHydraClient(hydraAdminUrl) {
     const updateClientResponse = await fetch(makeAbsolute(`clients/${OAUTH2_CLIENT_ID}`, hydraAdminUrl), {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(hydraClient)
+      body: JSON.stringify(hydraClientUpd)
     });
 
     if (updateClientResponse.status !== 200) {
@@ -55,7 +59,7 @@ async function ensureHydraClient(hydraAdminUrl) {
     const response = await fetch(makeAbsolute("/clients", hydraAdminUrl), {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify(hydraClient)
+      body: JSON.stringify(hydraClientUpd)
     });
 
     switch (response.status) {

--- a/src/getAccessToken.js
+++ b/src/getAccessToken.js
@@ -29,12 +29,12 @@ async function getAccessToken(userId, options) {
     hydraOAuthUrl = HYDRA_OAUTH_URL
   } = options || {};
 
-  await ensureHydraClient(hydraAdminUrl);
+  await ensureHydraClient(hydraAdminUrl, userId);
 
   // Initialize the OAuth2 Library
   const oauth2 = simpleOAuth2.create({
     client: {
-      id: OAUTH2_CLIENT_ID,
+      id: userId,
       secret: OAUTH2_CLIENT_SECRET
     },
     auth: {


### PR DESCRIPTION
fix when client_id not found when hydra return 401

```
$git clone https://github.com/reactioncommerce/hydra-token.git
$ cd hydra-token/src
$ node cli.js get --raw get-token-dev-script 
{"error":"The request could not be authorized","error_description":"The requested OAuth 2.0 client does not exist or you did not provide the necessary credentials","status_code":401,"request_id":""}

Could not get Hydra client [401]

```

the hydra return 401 even when client_id not found, so need to add 401 in 
https://github.com/passionofvc/hydra-token/blob/trunk/src/ensureHydraClient.js#L37

```
$ curl -s -H 'Content-Type: application/json' -H 'Accept: application/json' -X GET http://127.0.0.1:4445/clients/your_not_exists_client_id | jq .
{
  "error": "The request could not be authorized",
  "error_description": "The requested OAuth 2.0 client does not exist or you did not provide the necessary credentials",
  "status_code": 401,
  "request_id": ""
}
```

the doc say [/clients/:client_id] https://www.ory.sh/hydra/docs/v1.4/reference/api/#get-an-oauth-20-client
does not require authentication, so 404 will never happen.
